### PR TITLE
add azure api instead of openai

### DIFF
--- a/src/weaviate.ts
+++ b/src/weaviate.ts
@@ -7,7 +7,7 @@ export function getWeaviateClient(config: Config) {
     host: config.host,
     apiKey: new ApiKey(config.apiKey),
     headers: {
-      "X-Openai-Api-Key": config.openApiKey,
+      "X-Azure-Api-Key": config.openApiKey,
     },
   });
 }


### PR DESCRIPTION
- This PR adds Azure open ai key instead of open ai key. 
- At some point we might want to add support for both but I don't foresee us using and we can re-visit this when needed