### PR TITLE
Add score and explain score

### DIFF
--- a/src/handlers/schema.ts
+++ b/src/handlers/schema.ts
@@ -32,6 +32,18 @@ const builtInProperties: ColumnInfo[] = [
     // type: { element_type: "number", nullable: false, type: "array" },
     type: "vector",
   },
+  {
+    name: "score",
+    nullable: true,
+    insertable: true,
+    type: "real",
+  },
+  {
+    name: "explainScore",
+    nullable: true,
+    insertable: true,
+    type: "text",
+  },
 ];
 
 export const builtInPropertiesKeys = builtInProperties.map((p) => p.name);


### PR DESCRIPTION
This PR adds support to export `explainScore` and `score` from weaviate side to hasura via this GDC

```
Request Hasura

query MyQuery {
  vdb {
    VdbPageContent(limit: 1, where: {vector: {match_text: "dummy"}}) {
      id
      content
      explainScore
      score
    }
  }
}

---------
Response  from Hasura

{
  "data": {
    "vdb": {
      "VdbPageContent": [
        {
          "id": "f5f4bdc4-7c27-42a2-b8d4-fbb6aa5a0e06",
          "content": "This is some dummy",
          "explainScore": ", BM25F_dummy_frequency:1, BM25F_dummy_propLength:4",
          "score": "0.13076457"
        }
      ]
    }
  }
}
```