### PR TITLE
Add generative search functionality

### DIFF
--- a/src/handlers/capabilities.ts
+++ b/src/handlers/capabilities.ts
@@ -58,8 +58,10 @@ const scalarTypes: ScalarTypesCapabilities = {
       near_text: "text",
       match_text: "text",
       hybrid_match_text: "text",
+      ask_question: "text",
+      with_properties: "text"
     },
-  },
+  }
 };
 
 const capabilities: Capabilities = {

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -210,8 +210,12 @@ async function executeSingleQuery(
           field.type === "column" &&
           builtInPropertiesKeys.includes(field.column)
         ) {
-          const value =
-            row[alias as keyof typeof row][field.column as keyof typeof row];
+          let value = null;
+          if (alias !== "generate") {
+            value = row[alias as keyof typeof row][field.column as keyof typeof row];
+          } else {
+            value = row["_additional"]["generate"];
+          }
           return [alias, value];
         }
         if (
@@ -527,6 +531,7 @@ function expressionScalarValue(value: ScalarValue) {
 function queryFieldsAsString(fields: Record<string, Field>): string {
   return Object.entries(fields)
     .map(([alias, field]) => {
+      if (alias === "generate") return "";
       return `${alias}: ${fieldString(field)}`;
     })
     .join(" ");

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -151,7 +151,6 @@ async function executeSingleQuery(
   if (query.where) {
     const searchTextFilter = getSearchTextFilter(query.where);
     const searchProps = queryProperties(query.where);
-    console.log("***** searchTextFilter *****", searchProps);
     if (searchTextFilter.length > 0) {
       if (isTextFilter(query.where, "near_text")) {
         getter.withNearText({

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -166,7 +166,7 @@ async function executeSingleQuery(
           query: searchTextFilter.toString(),
           properties: searchProps,
         });
-      } else if(isTextFilter(query.where, "ask_question")) {
+      } else if (isTextFilter(query.where, "ask_question")) {
         getter.withHybrid({
           query: searchTextFilter.toString(),
           properties: searchProps,
@@ -403,7 +403,7 @@ export function queryWhereOperator(
         case "hybrid_match_text":
         case "ask_question":
         case "with_properties":
-          // silently ignore near_tex, match_text, hybrid_match_text or ask_question operator
+          // silently ignore near_text, match_text, hybrid_match_text or ask_question operator
           return null;
         default:
           throw new Error(

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -167,17 +167,13 @@ async function executeSingleQuery(
           properties: searchProps,
         });
       } else if(isTextFilter(query.where, "ask_question")) {
-        getter.withBm25({
+        getter.withHybrid({
           query: searchTextFilter.toString(),
           properties: searchProps,
         });
-        // getter.withNearText({
-        //   concepts: searchTextFilter,
-        // });
-        // getter.withGenerate({
-        //   groupedTask: searchTextFilter.toString(),
-        // });
-        
+        getter.withGenerate({
+          groupedTask: searchTextFilter.toString(),
+        });
       }
     }
   } 

--- a/src/handlers/schema.ts
+++ b/src/handlers/schema.ts
@@ -44,6 +44,12 @@ const builtInProperties: ColumnInfo[] = [
     insertable: true,
     type: "text",
   },
+  {
+    name: "certainty",
+    nullable: true,
+    insertable: true,
+    type: "real",
+  }
 ];
 
 export const builtInPropertiesKeys = builtInProperties.map((p) => p.name);

--- a/src/handlers/schema.ts
+++ b/src/handlers/schema.ts
@@ -49,7 +49,13 @@ const builtInProperties: ColumnInfo[] = [
     nullable: true,
     insertable: true,
     type: "real",
-  }
+  },
+  {
+    name: "generate",
+    nullable: true,
+    insertable: true,
+    type: "json",
+  },
 ];
 
 export const builtInPropertiesKeys = builtInProperties.map((p) => p.name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ server.register(FastifyCors, {
 server.get<{ Reply: CapabilitiesResponse }>(
   "/capabilities",
   async (request, _response) => {
-    server.log.info(
+    server.log.debug(
       { headers: request.headers, query: request.body },
       "capabilities.request"
     );
@@ -41,7 +41,7 @@ server.get<{ Reply: CapabilitiesResponse }>(
 );
 
 server.get<{ Reply: SchemaResponse }>("/schema", async (request, _response) => {
-  server.log.info(
+  server.log.debug(
     { headers: request.headers, query: request.body },
     "schema.request"
   );
@@ -53,7 +53,7 @@ server.get<{ Reply: SchemaResponse }>("/schema", async (request, _response) => {
 server.post<{ Body: QueryRequest; Reply: QueryResponse }>(
   "/query",
   async (request, _response) => {
-    server.log.info(
+    server.log.debug(
       { headers: request.headers, query: request.body },
       "query.request"
     );
@@ -68,7 +68,7 @@ server.post<{ Body: QueryRequest; Reply: QueryResponse }>(
 server.post<{ Body: MutationRequest; Reply: MutationResponse }>(
   "/mutation",
   async (request, _response) => {
-    server.log.info(
+    server.log.debug(
       { headers: request.headers, query: request.body },
       "mutation.request"
     );
@@ -81,7 +81,7 @@ server.post<{ Body: MutationRequest; Reply: MutationResponse }>(
 );
 
 server.get("/health", async (request, response) => {
-  server.log.info(
+  server.log.debug(
     { headers: request.headers, query: request.body },
     "health.request"
   );
@@ -89,7 +89,7 @@ server.get("/health", async (request, response) => {
 });
 
 process.on("SIGINT", () => {
-  server.log.info("interrupted");
+  server.log.error("interrupted");
   process.exit(0);
 });
 


### PR DESCRIPTION
This PR adds
- Generative search functionality 
- Search only with specified properties for `match_text` and `hybrid` 
- Fix logging as it is printing pout all the key information in the container
- Adds `certainty` score to the query 

```
query MyQuery {
  vdb {
    <Page..>(where: {vector: {match_text: "dummy", with_properties: "content"}}) {
      content
      explainScore
      score
      certainty
    }
  }
}

```
```
{
  "data": {
    "vdb": {
      "<Page..>": [
        {
          "content": "This is some dummy",
          "explainScore": ", BM25F_dummy_frequency:1, BM25F_dummy_propLength:4",
          "score": "0.13076457",
          "certainty": null
        }
      ]
    }
  }
}
```

