### PR TITLE
add groupby to aggregate queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "fastify": "^4.13.0",
         "mathjs": "^11.0.0",
         "pino-pretty": "^8.0.0",
-        "weaviate-ts-client": "^1.3.2",
+        "weaviate-ts-client": "^1.6.0",
         "xml2js": "github:Leonidas-from-XIV/node-xml2js"
       },
       "devDependencies": {
@@ -1113,9 +1113,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1280,9 +1280,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1294,13 +1298,13 @@
       "dev": true
     },
     "node_modules/weaviate-ts-client": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/weaviate-ts-client/-/weaviate-ts-client-1.3.2.tgz",
-      "integrity": "sha512-QdI9SlFePVoUK9M/G+ep9DeUgdLH13PERfuOcyMALE/ZgwP13KLW7VfRen+p79W5QQA+qecm8TnMoUtcW3woyg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/weaviate-ts-client/-/weaviate-ts-client-1.6.0.tgz",
+      "integrity": "sha512-1We0l8/uw6r8xnPsY8nSne1+/Ntd6o2JFq5LODqb63ac9v4QWDpT8dyPSRriUhif+IZ2Ttusw+w38361z72eaw==",
       "dependencies": {
-        "graphql-request": "^5.1.0",
+        "graphql-request": "^5.2.0",
         "isomorphic-fetch": "^3.0.0",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fastify": "^4.13.0",
     "mathjs": "^11.0.0",
     "pino-pretty": "^8.0.0",
-    "weaviate-ts-client": "^1.3.2",
+    "weaviate-ts-client": "^1.6.0",
     "xml2js": "github:Leonidas-from-XIV/node-xml2js"
   },
   "devDependencies": {

--- a/src/handlers/capabilities.ts
+++ b/src/handlers/capabilities.ts
@@ -59,8 +59,10 @@ const scalarTypes: ScalarTypesCapabilities = {
       match_text: "text",
       hybrid_match_text: "text",
       ask_question: "text",
+      generative_search: "text",
       with_properties: "text",
       with_groupedby: "text",
+      autocut: "text"
     },
     aggregate_functions: {
       group_by: "text",

--- a/src/handlers/capabilities.ts
+++ b/src/handlers/capabilities.ts
@@ -59,9 +59,14 @@ const scalarTypes: ScalarTypesCapabilities = {
       match_text: "text",
       hybrid_match_text: "text",
       ask_question: "text",
-      with_properties: "text"
+      with_properties: "text",
+      with_groupedby: "text",
     },
-  }
+    aggregate_functions: {
+      group_by: "text",
+      generate: "text"
+    },
+  },
 };
 
 const capabilities: Capabilities = {

--- a/src/handlers/capabilities.ts
+++ b/src/handlers/capabilities.ts
@@ -64,7 +64,6 @@ const scalarTypes: ScalarTypesCapabilities = {
     },
     aggregate_functions: {
       group_by: "text",
-      generate: "text"
     },
   },
 };

--- a/src/handlers/mutation.ts
+++ b/src/handlers/mutation.ts
@@ -1,12 +1,9 @@
 import {
   MutationRequest,
   MutationResponse,
-  QueryRequest,
-  QueryResponse,
 } from "@hasura/dc-api-types";
 import { Config } from "../config";
 import { getWeaviateClient } from "../weaviate";
-import def from "ajv/dist/vocabularies/discriminator";
 import { builtInPropertiesKeys } from "./schema";
 import { queryWhereOperator } from "./query";
 
@@ -45,7 +42,7 @@ export async function executeMutation(
         // todo: something with the response?
         const insertResponse = await creator.do();
 
-        console.log("insert response", JSON.stringify(insertResponse));
+        // console.log("insert response", JSON.stringify(insertResponse));
 
         // todo: handle returning fields, based on insert response.
 
@@ -70,7 +67,7 @@ export async function executeMutation(
 
         const deleteResponse = await deleter.do();
 
-        console.log("delete response", deleteResponse);
+        // console.log("delete response", deleteResponse);
 
         response.operation_results.push({
           affected_rows: deleteResponse.results?.matches!,

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -264,8 +264,7 @@ async function executeSingleQuery(
       })
     )
   );
-  if (query.aggregates && query.where ) {
-
+  if (query.aggregates) {
     const tableAggregates = await executeAggregateQuery(
       query,
       config,
@@ -289,7 +288,6 @@ async function executeSingleQuery(
     }
   }
   return { rows };
-
 }
 
 async function executeAggregateQuery(

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -201,7 +201,6 @@ async function executeSingleQuery(
       }
     }
   }
-  console.log("getter*******", JSON.stringify(getter, null, 2));
   const response = await getter.do();
 
   const rows = response.data.Get[table].map((row: any) =>
@@ -247,15 +246,6 @@ async function executeSingleQuery(
     )
   );
   if (query.aggregates && query.where ) {
-
-    if (query.aggregates.aggregate_generate) {
-      const aggregates = {
-        aggregate_generate: {
-          [table]: response.data.Get[table][0].generate,
-        }
-      }
-      return { rows, aggregates };
-    }
 
     const tableAggregates = await executeAggregateQuery(
       query,

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -214,7 +214,7 @@ async function executeSingleQuery(
           if (alias !== "generate") {
             value =
               row[alias as keyof typeof row][field.column as keyof typeof row];
-          } else {
+          } else if (alias === "generate") {
             value = row["_additional"]["generate"];
           }
           return [alias, value];

--- a/src/handlers/schema.ts
+++ b/src/handlers/schema.ts
@@ -35,27 +35,21 @@ const builtInProperties: ColumnInfo[] = [
   {
     name: "score",
     nullable: true,
-    insertable: true,
+    insertable: false,
     type: "real",
   },
   {
     name: "explainScore",
     nullable: true,
-    insertable: true,
+    insertable: false,
     type: "text",
   },
   {
     name: "certainty",
     nullable: true,
-    insertable: true,
+    insertable: false,
     type: "real",
-  },
-  {
-    name: "generate",
-    nullable: true,
-    insertable: true,
-    type: "json",
-  },
+  }
 ];
 
 export const builtInPropertiesKeys = builtInProperties.map((p) => p.name);

--- a/src/handlers/schema.ts
+++ b/src/handlers/schema.ts
@@ -53,9 +53,15 @@ const builtInProperties: ColumnInfo[] = [
   {
     name: "generate",
     nullable: true,
-    insertable: true,
+    insertable: false,
     type: "json",
-  }
+  },
+  {
+    name: "answer",
+    nullable: true,
+    insertable: false,
+    type: "json",
+  },
 ];
 
 export const builtInPropertiesKeys = builtInProperties.map((p) => p.name);

--- a/src/handlers/schema.ts
+++ b/src/handlers/schema.ts
@@ -49,6 +49,12 @@ const builtInProperties: ColumnInfo[] = [
     nullable: true,
     insertable: false,
     type: "real",
+  },
+  {
+    name: "generate",
+    nullable: true,
+    insertable: true,
+    type: "json",
   }
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ server.post<{ Body: QueryRequest; Reply: QueryResponse }>(
 
     const config = getConfig(request);
     const query = request.body;
+    console.log("query", JSON.stringify(query, null, 2));
     const response = await executeQuery(query, config);
     return response;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,6 @@ server.post<{ Body: QueryRequest; Reply: QueryResponse }>(
 
     const config = getConfig(request);
     const query = request.body;
-    console.log("query", JSON.stringify(query, null, 2));
     const response = await executeQuery(query, config);
     return response;
   }


### PR DESCRIPTION
This PR adds group by support for aggregate queries. 

Note: Unfortunately groupby queries are not possible using `Get` queries and same on `Aggregate` queries, we won't have keyword search with groupby. It will only work with semantic searches
https://weaviate.io/developers/weaviate/api/graphql/get#get-groupby
https://weaviate.io/developers/weaviate/api/graphql/aggregate#groupby-argument