### PR TITLE
add autocut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "fastify": "^4.13.0",
         "mathjs": "^11.0.0",
         "pino-pretty": "^8.0.0",
-        "weaviate-ts-client": "^1.3.2",
+        "weaviate-ts-client": "^1.6.0",
         "xml2js": "github:Leonidas-from-XIV/node-xml2js"
       },
       "devDependencies": {
@@ -1113,9 +1113,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1280,9 +1280,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1294,13 +1298,13 @@
       "dev": true
     },
     "node_modules/weaviate-ts-client": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/weaviate-ts-client/-/weaviate-ts-client-1.3.2.tgz",
-      "integrity": "sha512-QdI9SlFePVoUK9M/G+ep9DeUgdLH13PERfuOcyMALE/ZgwP13KLW7VfRen+p79W5QQA+qecm8TnMoUtcW3woyg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/weaviate-ts-client/-/weaviate-ts-client-1.6.0.tgz",
+      "integrity": "sha512-1We0l8/uw6r8xnPsY8nSne1+/Ntd6o2JFq5LODqb63ac9v4QWDpT8dyPSRriUhif+IZ2Ttusw+w38361z72eaw==",
       "dependencies": {
-        "graphql-request": "^5.1.0",
+        "graphql-request": "^5.2.0",
         "isomorphic-fetch": "^3.0.0",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fastify": "^4.13.0",
     "mathjs": "^11.0.0",
     "pino-pretty": "^8.0.0",
-    "weaviate-ts-client": "^1.3.2",
+    "weaviate-ts-client": "^1.6.0",
     "xml2js": "github:Leonidas-from-XIV/node-xml2js"
   },
   "devDependencies": {

--- a/src/handlers/capabilities.ts
+++ b/src/handlers/capabilities.ts
@@ -62,6 +62,7 @@ const scalarTypes: ScalarTypesCapabilities = {
       generative_search: "text",
       with_properties: "text",
       with_groupedby: "text",
+      autocut: "text"
     },
     aggregate_functions: {
       group_by: "text",

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -151,7 +151,12 @@ async function executeSingleQuery(
   if (query.where) {
     const searchTextFilter = getSearchTextFilter(query.where);
     const searchProps = queryProperties(query.where, "with_properties");
+    const autocut = queryProperties(query.where, "autocut");
+
     if (searchTextFilter.length > 0) {
+      if (autocut) {
+        getter.withAutocut(autocut[0] as unknown as number);
+      }
       if (isTextFilter(query.where, "near_text")) {
         getter.withNearText({
           concepts: searchTextFilter,
@@ -358,14 +363,15 @@ function getSearchTextFilter(
         case "generative_search":
         case "with_properties":
         case "with_groupedby":
+        case "autocut":
           if (negated) {
             throw new Error(
-              "Negated near_text or match_text or hybrid_match_text or ask_question or generative search not supported"
+              "Negated near_text or match_text or hybrid_match_text or ask_question or generative search or autocut not supported"
             );
           }
           if (ored) {
             throw new Error(
-              "Ored near_text or match_text or hybrid_match_text or ask_question or generative search not supported"
+              "Ored near_text or match_text or hybrid_match_text or ask_question or generative search or autocut not supported"
             );
           }
           switch (expression.value.type) {
@@ -411,7 +417,7 @@ export function queryWhereOperator(
         return null;
       }
       return {
-        operator: "Not",
+        operator: "NotEqual",
         operands: [expr],
       };
     case "and":
@@ -492,7 +498,8 @@ export function queryWhereOperator(
         case "generative_search":
         case "with_properties":
         case "with_groupedby":
-          // silently ignore near_text, match_text, hybrid_match_text or ask_question or generative search operator
+        case "autocut":
+          // silently ignore near_text, match_text, hybrid_match_text or ask_question or generative search or autocut operator
           return null;
         default:
           throw new Error(


### PR DESCRIPTION
This PR adds autocrat to cut down results with low certainty. Upgraded the `weaviate-ts-client` which supports this feature

https://weaviate.io/developers/weaviate/api/graphql/additional-operators#autocut 

Note: The value for `autocut` is being taken as `text` and being casted into `int`. Int input is causing issues on the hasura side otherwise. 

